### PR TITLE
Adding BackdropCommerceEntityController via hook_autoload_info()

### DIFF
--- a/modules/customer/commerce_customer.module
+++ b/modules/customer/commerce_customer.module
@@ -1553,6 +1553,7 @@ function commerce_customer_config_info() {
  */
 function commerce_customer_autoload_info() {
   return [
+    'BackdropCommerceEntityController' => 'includes/commerce.controller.inc',
     'CommerceCustomerProfile' => 'includes/commerce_customer.entity.inc',
     'CommerceCustomerProfileEntityController' => 'includes/commerce_customer_profile.controller.inc',
     'commerce_customer_handler_area_empty_text' => 'includes/views/handlers/commerce_customer_handler_area_empty_text.inc',


### PR DESCRIPTION
Fixes #40

This fixes an error we were getting when we enabled commerce_customer, Class "BackdropCommerceEntityController" not found in require_once() (line 12 of /var/www/backdrop.local/modules/commerce/modules/customer/includes/commerce_customer_profile.controller.inc).

We just needed to make sure we were including that class in hook_autoload_info() in the commerce_customer module.