### PR TITLE
Fixes for Commerce Customer submodule config

### DIFF
--- a/modules/customer/commerce_customer.install
+++ b/modules/customer/commerce_customer.install
@@ -244,3 +244,20 @@ function commerce_customer_update_1002() {
     $config->save();
   }
 }
+
+/**
+  * We're adding this for the small handful of early adopters who were using
+  * the unreleased Backdrop module.
+ */
+function commerce_customer_update_1003() {
+  $config = config('commerce_customer.settings');
+  $config->clear('commerce_customer_profile_type_field');
+  $config->set('commerce_customer_profile_billing_profile_copy', 'false');
+  $config->set('commerce_customer_profile_billing_profile_copy_default', 'true');
+  $config->set('commerce_customer_profile_billing_profile_copy_source', 'shipping');
+  $config->set('commerce_customer_profile_shipping_field', 'commerce_customer_shipping');
+  $config->set('commerce_customer_profile_shipping_profile_copy', 'true');
+  $config->set('commerce_customer_profile_shipping_profile_copy_default', 'true');
+  $config->set('commerce_customer_profile_shipping_profile_copy_source', 'billing');
+  $config->save();
+}

--- a/modules/customer/config/commerce_customer.settings.json
+++ b/modules/customer/config/commerce_customer.settings.json
@@ -1,6 +1,12 @@
 {
     "_config_name": "commerce_customer.settings",
-    "commerce_customer_profile_type_field": "commerce_customer_address",
-    "anonymous": "Anonymous",
-    "commerce_customer_profile_billing_field": "commerce_customer_billing"
+    "commerce_customer_profile_billing_field": "commerce_customer_billing",
+    "commerce_customer_profile_billing_profile_copy": false,
+    "commerce_customer_profile_billing_profile_copy_default": true,
+    "commerce_customer_profile_billing_profile_copy_source": "shipping",
+    "commerce_customer_profile_shipping_field": "commerce_customer_shipping",
+    "commerce_customer_profile_shipping_profile_copy": true,
+    "commerce_customer_profile_shipping_profile_copy_default": true,
+    "commerce_customer_profile_shipping_profile_copy_source": "billing",
+    "anonymous": "Anonymous"
 }

--- a/modules/customer/includes/commerce_customer.checkout_pane.inc
+++ b/modules/customer/includes/commerce_customer.checkout_pane.inc
@@ -10,19 +10,19 @@
  * Checkout pane callback: returns the customer profile pane's settings form.
  */
 function commerce_customer_profile_pane_settings_form($checkout_pane) {
-  $commerce = config_get('commerce_checkout.settings', 'commerce_' . $checkout_pane['pane_id'] . '_field');
+  $commerce = config_get('commerce_customer.settings', 'commerce_' . $checkout_pane['pane_id'] . '_field');
   if (!isset($commerce) || empty($commerce) || $commerce == NULL) {
     $commerce = '';
   }
-  $profile_copy = config_get('commerce_checkout.settings', 'commerce_' . $checkout_pane['pane_id'] . '_profile_copy');
+  $profile_copy = config_get('commerce_customer.settings', 'commerce_' . $checkout_pane['pane_id'] . '_profile_copy');
   if (!isset($profile_copy) || empty($profile_copy) || $profile_copy == NULL) {
     $profile_copy = FALSE;
   }
-  $profile_copy_source = config_get('commerce_checkout.settings', 'commerce_' . $checkout_pane['pane_id'] . '_profile_copy_source');
+  $profile_copy_source = config_get('commerce_customer.settings', 'commerce_' . $checkout_pane['pane_id'] . '_profile_copy_source');
   if (!isset($profile_copy_source) || empty($profile_copy_source) || $profile_copy_source == NULL) {
     $profile_copy_source = NULL;
   }
-  $profile_copy_def = config_get('commerce_checkout.settings', 'commerce_' . $checkout_pane['pane_id'] . '_profile_copy_default');
+  $profile_copy_def = config_get('commerce_customer.settings', 'commerce_' . $checkout_pane['pane_id'] . '_profile_copy_default');
   if (!isset($profile_copy_def) || empty($profile_copy_def) || $profile_copy_def == NULL) {
     $profile_copy_def = TRUE;
   }
@@ -96,19 +96,19 @@ function commerce_customer_profile_pane_settings_form($checkout_pane) {
  * Checkout pane callback: returns a customer profile edit form.
  */
 function commerce_customer_profile_pane_checkout_form($form, &$form_state, $checkout_pane, $order) {
-  $commerce = config_get('commerce_checkout.settings', 'commerce_' . $checkout_pane['pane_id'] . '_field');
+  $commerce = config_get('commerce_customer.settings', 'commerce_' . $checkout_pane['pane_id'] . '_field');
   if (!isset($commerce) || empty($commerce) || $commerce == NULL) {
     $commerce = '';
   }
-  $profile_copy = config_get('commerce_checkout.settings', 'commerce_' . $checkout_pane['pane_id'] . '_profile_copy');
+  $profile_copy = config_get('commerce_customer.settings', 'commerce_' . $checkout_pane['pane_id'] . '_profile_copy');
   if (!isset($profile_copy) || empty($profile_copy) || $profile_copy == NULL) {
     $profile_copy = FALSE;
   }
-  $profile_copy_source = config_get('commerce_checkout.settings', 'commerce_' . $checkout_pane['pane_id'] . '_profile_copy_source');
+  $profile_copy_source = config_get('commerce_customer.settings', 'commerce_' . $checkout_pane['pane_id'] . '_profile_copy_source');
   if (!isset($profile_copy_source) || empty($profile_copy_source) || $profile_copy_source == NULL) {
     $profile_copy_source = NULL;
   }
-  $profile_copy_def = config_get('commerce_checkout.settings', 'commerce_' . $checkout_pane['pane_id'] . '_profile_copy_default');
+  $profile_copy_def = config_get('commerce_customer.settings', 'commerce_' . $checkout_pane['pane_id'] . '_profile_copy_default');
   if (!isset($profile_copy_def) || empty($profile_copy_def) || $profile_copy_def == NULL) {
     $profile_copy_def = FALSE;
   }
@@ -260,7 +260,7 @@ function commerce_customer_profile_pane_checkout_form($form, &$form_state, $chec
  */
 function commerce_customer_profile_copy_refresh($form, &$form_state) {
   $pane_id = reset($form_state['triggering_element']['#parents']);
-  
+
   $commands = [];
 
   // Render the pane afresh to capture any changes based on address entry.
@@ -277,7 +277,7 @@ function commerce_customer_profile_copy_refresh($form, &$form_state) {
  */
 function commerce_customer_profile_pane_checkout_form_validate($form, &$form_state, $checkout_pane, $order) {
   $pane_id = $checkout_pane['pane_id'];
-  $field = config_get('commerce_checkout.settings', 'commerce_' . $pane_id . '_field');
+  $field = config_get('commerce_customer.settings', 'commerce_' . $pane_id . '_field');
   if (!isset($field) || empty($field) || $field == NULL) {
     $field = '';
   }
@@ -314,7 +314,7 @@ function commerce_customer_profile_pane_checkout_form_validate($form, &$form_sta
 function commerce_customer_profile_pane_checkout_form_submit($form, &$form_state, $checkout_pane, $order) {
   $pane_id = $checkout_pane['pane_id'];
 
-  $field = config_get('commerce_checkout.settings', 'commerce_' . $pane_id . '_field');
+  $field = config_get('commerce_customer.settings', 'commerce_' . $pane_id . '_field');
   if (!isset($field) || empty($field) || $field == NULL) {
     $field = '';
   }
@@ -358,7 +358,7 @@ function commerce_customer_profile_pane_checkout_form_submit($form, &$form_state
  *   Review checkout pane.
  */
 function commerce_customer_profile_pane_review($form, $form_state, $checkout_pane, $order) {
-  $commerce = config_get('commerce_checkout.settings', 'commerce_' . $checkout_pane['pane_id'] . '_field');
+  $commerce = config_get('commerce_customer.settings', 'commerce_' . $checkout_pane['pane_id'] . '_field');
   if (!isset($commerce) || empty($commerce) || $commerce == NULL) {
     $commerce = '';
   }


### PR DESCRIPTION
Our original port incorrectly referenced config in Commerce Checkout that didn't exist. This commit adds this config to the Commerce Customer submodule where it belongs, and updates the code to point to the correct configuration file.

This will fix an issue where Commerce orders and addresses were getting stored in the database, but weren't linked to one another. It also should solve the profile copying issues that we detected during a failed test that is referenced in Issue 29.

We know a few users have the unreleased version of this module, so we're adding an update hook to commerce_customer to make sure they receive this change as well on upgrade.