### PR TITLE
Add Commerce Checkout dependency to Commerce Customer

### DIFF
--- a/modules/customer/commerce_customer.info
+++ b/modules/customer/commerce_customer.info
@@ -4,6 +4,7 @@ package = Commerce
 dependencies[] = system (>=1.31.1)
 dependencies[] = addressfield
 dependencies[] = commerce
+dependencies[] = commerce_checkout
 dependencies[] = entity
 backdrop = 1.x
 type = module


### PR DESCRIPTION
Commerce Customer requires the commerce_customer_billing field to be present, but that field only gets installed when you enable Commerce Checkout.